### PR TITLE
Testing nix develop on macOS x86_64, and other architectures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -934,9 +934,9 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.5.0-dev.9"
+version = "0.5.0-dev.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496fab25a7da57d4473ec3afd676c097fa6b1e579e7f97cf7ccfe409b391f079"
+checksum = "9dd62de0d29f215642cb2481ec5cdde81233c3fabe97157c8a35118b69dd821d"
 dependencies = [
  "getrandom",
  "hdk_derive",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.4.0-dev.10"
+version = "0.4.0-dev.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c64cad926b27bbf72c447f8f8e3b53946458c0987a5b09f40d894aaa2bb143b"
+checksum = "b63439a2fa623ae819ad41037c00216f1d62dc78aa9e9e5458f987866c08254f"
 dependencies = [
  "getrandom",
  "hdi",

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,29 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720781449,
-        "narHash": "sha256-po3TZO9kcZwzvkyMJKb0WCzzDtiHWD34XeRaX1lWXp0=",
+        "lastModified": 1722141560,
+        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b5a3d5a1d951344d683b442c0739010b80039db",
+        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
         "type": "github"
       },
       "original": {
@@ -18,7 +35,23 @@
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -19,11 +19,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722141560,
-        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
+        "lastModified": 1722640603,
+        "narHash": "sha256-TcXjLVNd3VeH1qKPH335Tc4RbFDbZQX+d7rqnDUoRaY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
+        "rev": "81610abc161d4021b29199aa464d6a1a521e0cc9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,14 +23,14 @@
               holochain_0-4
               lair-keystore_0-4-5
               hc_0-4
-    
+
               rustup
               cargo
               rustc
-    
+
               nodejs_22
             ];
-    
+
             shellHook = ''
               export PS1="\[\e[1;32m\](flake-env)\[\e[0m\] \[\e[1;34m\]\u@\h:\w\[\e[0m\]$ "
               rustup target add wasm32-unknown-unknown

--- a/flake.nix
+++ b/flake.nix
@@ -5,35 +5,39 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   };
 
-  outputs = { self, nixpkgs }:
-    let
-      system = "x86_64-linux";
-      pkgs = import ./pkgs.nix {
-        pkgs = nixpkgs.legacyPackages.${system};
-        inherit system;
-      };
-    in
-    {
-      devShells.${system} = {
-        default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            holochain_0-4
-            lair-keystore_0-4-5
-            hc_0-4
-
-            rustup
-            cargo
-            rustc
-
-            nodejs_22
-          ];
-
-          shellHook = ''
-            export PS1="\[\e[1;32m\](flake-env)\[\e[0m\] \[\e[1;34m\]\u@\h:\w\[\e[0m\]$ "
-            rustup default stable
-            rustup target add wasm32-unknown-unknown
-          '';
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import ./pkgs.nix {
+          pkgs = nixpkgs.legacyPackages.${system};
+          inherit system;
         };
-      };
-    };
+	#debugLog = builtins.trace "pkgs output: ${builtins.toJSON pkgs}";
+        debugLog = builtins.trace "Available attributes: ${builtins.toString (builtins.attrNames pkgs)}";
+      in
+      {
+        #devShell = {
+        #  default = pkgs.mkShell {
+        devShell = debugLog (pkgs.mkShell {
+            buildInputs = with pkgs; [
+              holochain_0-4
+              lair-keystore_0-4-5
+              hc_0-4
+    
+              rustup
+              cargo
+              rustc
+    
+              nodejs_22
+            ];
+    
+            shellHook = ''
+              export PS1="\[\e[1;32m\](flake-env)\[\e[0m\] \[\e[1;34m\]\u@\h:\w\[\e[0m\]$ "
+              rustup target add wasm32-unknown-unknown
+            '';
+        });
+        #  };
+        #};
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -12,13 +12,9 @@
           pkgs = nixpkgs.legacyPackages.${system};
           inherit system;
         };
-	#debugLog = builtins.trace "pkgs output: ${builtins.toJSON pkgs}";
-        debugLog = builtins.trace "Available attributes: ${builtins.toString (builtins.attrNames pkgs)}";
       in
       {
-        #devShell = {
-        #  default = pkgs.mkShell {
-        devShell = debugLog (pkgs.mkShell {
+        devShell = pkgs.mkShell {
             buildInputs = with pkgs; [
               holochain_0-4
               lair-keystore_0-4-5
@@ -29,15 +25,17 @@
               rustc
 
               nodejs_22
+            ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              libiconv  # for test-fuzz-macro on macOS x86_64
             ];
 
             shellHook = ''
               export PS1="\[\e[1;32m\](flake-env)\[\e[0m\] \[\e[1;34m\]\u@\h:\w\[\e[0m\]$ "
+              rustup update
+              rustup default stable
               rustup target add wasm32-unknown-unknown
             '';
-        });
-        #  };
-        #};
+        };
       }
     );
 }

--- a/mere_memory/Cargo.lock
+++ b/mere_memory/Cargo.lock
@@ -896,9 +896,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hdi"
-version = "0.5.0-dev.9"
+version = "0.5.0-dev.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496fab25a7da57d4473ec3afd676c097fa6b1e579e7f97cf7ccfe409b391f079"
+checksum = "9dd62de0d29f215642cb2481ec5cdde81233c3fabe97157c8a35118b69dd821d"
 dependencies = [
  "getrandom",
  "hdk_derive",

--- a/mere_memory_types/Cargo.toml
+++ b/mere_memory_types/Cargo.toml
@@ -13,7 +13,7 @@ name = "mere_memory_types"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-hdi = "0.5.0-dev.9"
+hdi = "0.5.0-dev.10"
 serde = "1"
 
 [dev-dependencies]

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,10 +1,11 @@
 { pkgs, system }:
 
 import (pkgs.fetchFromGitHub {
-  owner = "spartan-holochain-counsel";
+  #owner = "spartan-holochain-counsel";
+  owner = "pjkundert";
   repo = "nix-overlay";
-  rev = "60304b93954c201cb4e1f75eb17295789e1bf967";
-  sha256 = "qgewX2TbZdlPRkGPvyvUmo7gDj4122JGypi1uwdXcTg=";
+  rev = "dbd4d2b28d861a9536a89d7012a730ebbca28676"; # feature-arch
+  sha256 = "sha256-xeE4gFEssB17Hr69JepP2k5J8uwrSQdpMtvn99Pd7oQ=";
 }) {
   inherit pkgs;
   inherit system;

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,11 +1,10 @@
 { pkgs, system }:
 
 import (pkgs.fetchFromGitHub {
-  #owner = "spartan-holochain-counsel";
-  owner = "pjkundert";
+  owner = "spartan-holochain-counsel";
   repo = "nix-overlay";
-  rev = "280242a915aefcc7dcad7b3b7333673b4cab8483"; # feature-arch
-  sha256 = "sha256-OqTnBtT2pQcq1rLlEh6uorzSKbsIHYNR5Ebpts8309U=";
+  rev = "5bae4a38735d74633c9c089b5c896cb9631a295b";
+  sha256 = "E/FvMyUgEB5MYL+s46YSiHPOAJiurKZDMQy1oxak6bg=";
 }) {
   inherit pkgs;
   inherit system;

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -4,8 +4,8 @@ import (pkgs.fetchFromGitHub {
   #owner = "spartan-holochain-counsel";
   owner = "pjkundert";
   repo = "nix-overlay";
-  rev = "dbd4d2b28d861a9536a89d7012a730ebbca28676"; # feature-arch
-  sha256 = "sha256-xeE4gFEssB17Hr69JepP2k5J8uwrSQdpMtvn99Pd7oQ=";
+  rev = "280242a915aefcc7dcad7b3b7333673b4cab8483"; # feature-arch
+  sha256 = "sha256-OqTnBtT2pQcq1rLlEh6uorzSKbsIHYNR5Ebpts8309U=";
 }) {
   inherit pkgs;
   inherit system;


### PR DESCRIPTION
Here's a stab at getting this to build and test on macOS x86_64; passes 'make test'.

For some reason, I needed to perform the 'rustup update', or the version of rustc and cargo were not compatible.  This doesn't seem to be the ideal method for reliably making available the correct versions of Rust and Cargo?

Also, macOS seemed to require libiconv; perhaps there's a better way to satisfy these architecture dependent requirements.

When feature-arch gets merged into nix-overlay upstream, pkgs.nix should use that instead.